### PR TITLE
Add initial MiniLoop package

### DIFF
--- a/py_async_lib/__init__.py
+++ b/py_async_lib/__init__.py
@@ -1,0 +1,5 @@
+"""Minimal asynchronous library utilities."""
+
+from .mini_loop import MiniLoop
+
+__all__ = ["MiniLoop"]

--- a/py_async_lib/mini_loop.py
+++ b/py_async_lib/mini_loop.py
@@ -1,0 +1,10 @@
+from collections import deque
+
+class MiniLoop:
+    """A minimal event loop implementation."""
+
+    def __init__(self):
+        # Queue for ready-to-run callbacks
+        self.ready = deque()
+        # Timers managed as a min-heap of (when, callback) tuples
+        self.timers = []


### PR DESCRIPTION
## Summary
- set up `py_async_lib` package with `__init__` file
- implement basic `MiniLoop` class
- expose `MiniLoop` at package level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728f15390c83318b81d8ad8967463c