### PR TITLE
Add printer example and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # py_async_lib
 My own custom implementation of the Ansycio library from scratch using C Wrappers and Python
+
+## Example
+
+Run the small loop demo in `examples/printer.py`:
+
+```bash
+PYTHONPATH=. python examples/printer.py
+```

--- a/examples/printer.py
+++ b/examples/printer.py
@@ -1,0 +1,16 @@
+from py_async_lib.mini_loop import MiniLoop, sleep
+
+
+def printer(name, delay, count):
+    """Coroutine that prints ``name`` every ``delay`` seconds for ``count`` iterations."""
+    for _ in range(count):
+        print(name)
+        # Yield control back to the loop for the specified delay
+        yield from sleep(delay)
+
+
+if __name__ == "__main__":
+    loop = MiniLoop()
+    loop.create_task(printer("A", 1, 3))
+    loop.create_task(printer("B", 0.5, 5))
+    loop.run()


### PR DESCRIPTION
## Summary
- add `examples/printer.py` demonstrating the custom MiniLoop with two coroutines
- document running the example in README

## Testing
- `python -m py_compile examples/printer.py`
- `PYTHONPATH=. python examples/printer.py`

------
https://chatgpt.com/codex/tasks/task_e_687291b0e3448331a39a5add17c79b06