### PR TITLE
Add missing tests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ import py_async_lib
 py_async_lib.install()
 ```
 
+### Running tests
+
+Install the package in editable mode and run the test suite with `pytest`:
+
+```bash
+pip install -e .
+pytest
+```
+
+The tests exercise each milestone from issues **#1** through **#9**, covering the
+Python mini loop, the C event loop skeleton, I/O watchers, subprocess helpers and
+signal handling.
+
 ### Development progress
 
 The C event loop now includes an `OutBuf` structure for managing pending writes.

--- a/project/tests/test_casyncio.py
+++ b/project/tests/test_casyncio.py
@@ -3,8 +3,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 import casyncio
 import gc
+import signal
+import asyncio
 import socket
 from py_async_lib.stream_writer import StreamWriter
+from py_async_lib import install
 
 
 def test_create_and_destroy():
@@ -50,3 +53,57 @@ def test_streamwriter_write_and_drain():
 
     r.close()
     w.close()
+
+def test_add_reader_is_called():
+    loop = casyncio.EventLoop()
+    r, w = socket.socketpair()
+    r.setblocking(False)
+    w.setblocking(False)
+    results = []
+
+    def reader():
+        data = r.recv(1)
+        results.append(data)
+        loop.stop()
+
+    loop.add_reader(r.fileno(), reader)
+    w.send(b'X')
+    loop.run_forever()
+
+    assert results == [b'X']
+    r.close()
+    w.close()
+
+
+def test_signal_handler():
+    loop = casyncio.EventLoop()
+    called = []
+
+    def handler():
+        called.append(True)
+        loop.stop()
+
+    loop.add_signal_handler(signal.SIGTERM, handler)
+    # Add a dummy reader so the loop waits for epoll events
+    r, w = socket.socketpair()
+    loop.add_reader(r.fileno(), lambda: None)
+
+    os.kill(os.getpid(), signal.SIGTERM)
+    loop.run_forever()
+
+    loop.remove_reader(r.fileno())
+    r.close()
+    w.close()
+
+    assert called == [True]
+
+
+def test_install_sets_event_loop_policy():
+    old = asyncio.get_event_loop_policy()
+    install()
+    try:
+        loop = asyncio.new_event_loop()
+        assert isinstance(loop, casyncio.EventLoop)
+    finally:
+        asyncio.set_event_loop_policy(old)
+

--- a/tests/test_mini_loop.py
+++ b/tests/test_mini_loop.py
@@ -2,6 +2,7 @@ import sys, os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
+import time
 
 from py_async_lib.mini_loop import MiniLoop, sleep
 
@@ -39,3 +40,20 @@ def test_loop_exits_when_done(capsys):
     loop.run()
     second_run = capsys.readouterr().out
     assert second_run == ""
+
+def test_call_later_runs_after_delay():
+    """call_later should schedule a coroutine after the given delay."""
+    loop = MiniLoop()
+    events = []
+
+    def coro():
+        events.append("done")
+        if False:
+            yield  # pragma: no cover
+
+    loop.call_later(0.01, coro())
+    start = time.time()
+    loop.run()
+    elapsed = time.time() - start
+    assert events == ["done"]
+    assert elapsed >= 0.01


### PR DESCRIPTION
## Summary
- document running tests in README
- add timer test for MiniLoop
- add C loop tests for readers, signal handling and install helper

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687307fd25308331b8e46faf4ca04224