### PR TITLE
Implement thread-safe callbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ The repository currently tracks the step-by-step implementation of an asyncio-li
 9. **#9** – Work toward becoming a fully fledged event loop compatible with `asyncio`.
 10. **#10** – Profiling and final optimizations.
 11. **#11** – Heap-based timers and `call_later`.
-12. **#12** – Thread-safe callbacks.
+12. **#12** – Thread-safe callbacks (implemented).
 13. **#13** – `run_in_executor` and async DNS resolution.
 14. **#14** – High-level stream abstractions.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ erDiagram
 *   **`FDCallback`**: Stores the `reader` and `writer` callbacks for a single file descriptor.
 *   **`OutBuf`**: A write buffer associated with an `FDCallback`. It holds the data to be written and a list of `Future` objects (`waiters`) to be notified upon successful drainage.
 
+### Thread-safe callbacks
+
+The loop exposes `call_soon_threadsafe()` to schedule callbacks from other threads. A self-pipe wakes the event loop so the function can be safely used from worker threads without race conditions.
+
 ## 🚀 Benchmark
 
 You can compare the throughput of the project's event loop against Python's built-in `asyncio` loop with the benchmark script:
@@ -192,6 +196,6 @@ The development of the C event loop is tracked through a series of issues, each 
 *   **#9**: Full compatibility with the `asyncio` event loop policy.
 *   **#10**: Profiling and final optimizations.
 *   **#11**: Implementation of timers with `call_later`.
-*   **#12**: Thread-safe callbacks.
+*   **#12**: Thread-safe callbacks (implemented).
 *   **#13**: Asynchronous DNS lookups via executors.
 *   **#14**: High-level stream abstractions.

--- a/project/src/loop.h
+++ b/project/src/loop.h
@@ -42,6 +42,8 @@ typedef struct {
     int sfd;
     PyObject *signal_handlers;
     int running;
+    int aw_rfd;
+    int aw_wfd;
 } PyEventLoopObject;
 
 #endif // CASYNCIO_LOOP_H


### PR DESCRIPTION
## Summary
- implement call_soon_threadsafe in the C loop
- wake the event loop through a self-pipe
- expose new method in the module API
- add tests for the new functionality
- document thread-safe callbacks in README and mark step 12 complete in AGENTS

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68795f44284c8331940fbe724cd595ef